### PR TITLE
Add option for using a custom client

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ $ npm install cassandra-store
 - `contactPoints`: [ "host1", "host2" ]
 - `keyspace`: "tests"
 - `protocolOptions`: JSON object `{ "port": 9042 }`
+- `client`: Cassandra client. For compatibility, the client must expose the same functionality as the [driver](https://github.com/datastax/nodejs-driver) (version 2.x).
+- `table`: ColumnFamily in which the sessions are stored. Default: `"sessions"`
 
 For example:
 
@@ -27,21 +29,20 @@ For example:
     "authProvider": {
         "username": "",
         "password": ""
-    }
+    },
+    "table": "sessions"
 }
 ```
 
 Other options come from the [Cassandra client driver](https://docs.datastax.com/en/developer/nodejs-driver/2.2/nodejs-driver/whatsNew.html) (version 2.x).
 
+
 ## Configuring the database
 
-To create the table in the Cassandra database, you need the execute the
-following CQL commands:
+To use the store with it's default configuration, you need the create the table in the Cassandra database, by executing the following CQL:
 
 ```
-CREATE KEYSPACE tests
-  WITH replication = {'class': 'SimpleStrategy', 'dataCenterName': 1};
-CREATE TABLE IF NOT EXISTS sessions (
+CREATE TABLE sessions (
    sid text PRIMARY KEY,
    sobject text
 );
@@ -57,6 +58,22 @@ var CassandraStore = require("cassandra-store")(session);
 
 app.use(session({
     store: new CassandraStore(options),
+    ...
+}));
+```
+
+Usage within express and custom client:
+
+```
+var session = require("express-session");
+var CassandraStore = require("cassandra-store")(session);
+
+var myClient = require('<my-client>');
+
+app.use(session({
+    store: new CassandraStore({
+        client: myClient
+    }),
     ...
 }));
 ```

--- a/lib/cassandra-store.js
+++ b/lib/cassandra-store.js
@@ -21,7 +21,6 @@ module.exports = function (session)
     /**
      * Default variables.
      */
-    var TABLE = "sessions";
     var defaultOptions = {
         "contactPoints": [ "localhost" ],
         "keyspace": "tests",
@@ -39,7 +38,8 @@ module.exports = function (session)
         "authProvider": {
             "username": "",
             "password": ""
-        }
+        },
+        "table": "sessions"
     };
 
     /**
@@ -58,28 +58,28 @@ module.exports = function (session)
         options = _.extend(defaultOptions, options);
         Store.call(this, options);
         this.options = options;
-        this.client = new cassandra.Client(options);
-        if(this.options.keyspace)
-        {
-            TABLE = this.options.keyspace + "." + TABLE;
-        }
-        debug("Database configuration: ", JSON.stringify(this.options, null, 0));
-        debug("Database table: ", TABLE);
+        this.client = options.client || new cassandra.Client(options);
+        this.table = options.table;
+        debug("Database configuration: %j", this.client.options);
+        debug("Database table: ", this.table);
         this.client.on("log", function(level, className, message, furtherInfo)
         {
             debug("%s [%s]: %s (%s)", className, level, message, furtherInfo);
         });
-        this.client.connect(function (error)
+        if(!this.client.connected)
         {
-            if (error)
-            {
-                debug("Database not available: " + error.message);
-            }
-            else
-            {
-                debug("Database store initialized");
-            }
-        });
+          this.client.connect(function (error)
+          {
+              if (error)
+              {
+                  debug("Database not available: " + error.message);
+              }
+              else
+              {
+                  debug("Database store initialized");
+              }
+          });
+        }
     }
 
     /**
@@ -96,9 +96,9 @@ module.exports = function (session)
      */
     CassandraStore.prototype.get = function (sid, fn)
     {
-        var query = util.format(Queries.SELECT, TABLE, sid);
+        var query = util.format(Queries.SELECT, this.table, sid);
         debug("Query: %s", query);
-        this.client.execute(query, this.options.queryOptions,
+        this.client.execute(query, this.client.options.queryOptions,
             function (error, result)
         {
             var sess = null;
@@ -141,10 +141,10 @@ module.exports = function (session)
     CassandraStore.prototype.set = function (sid, sess, fn)
     {
         var sobject = JSON.stringify(sess, null, 0);
-        var query = util.format(Queries.UPDATE, TABLE,
+        var query = util.format(Queries.UPDATE, this.table,
             Math.round(sess.cookie.maxAge / 1000), sobject, sid);
         debug("Query: %s", query);
-        this.client.execute(query, this.options.queryOptions,
+        this.client.execute(query, this.client.options.queryOptions,
             function (error, result)
         {
             if (error)
@@ -169,7 +169,7 @@ module.exports = function (session)
      */
     CassandraStore.prototype.destroy = function (sid, fn)
     {
-        var query = util.format(Queries.DELETE, TABLE, sid);
+        var query = util.format(Queries.DELETE, this.table, sid);
         debug("Query: %s", query);
         this.client.execute(query, this.options.queryOptions,
             function (error, result)


### PR DESCRIPTION
Even though most cases will be fine using the default options, it might be required usage with a custom client. Reasons:

- Ability to use a custom client as long as the interface is compatible
- If Cassandra is used for storing other data, there is no need to maintain multiple 

I also added the option of changing the session column family name. One might want to store sessions in different tables (considering multiple applications, while using the same Cassandra cluster + keyspace).
  
I will leave comments on the code better describing what happens.