### PR TITLE
upgrade cassandra-driver to v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "email": "webcc@fit.fraunhofer.de"
     },
     "dependencies": {
-        "cassandra-driver": "2.2.2",
+        "cassandra-driver": "^3.0.0",
         "debug": "2.2.0",
         "express-session": "1.12.1",
         "underscore": "1.8.3"


### PR DESCRIPTION
Getting the following error due to outdated driver:

cassandra-store ControlConnection [error]: ControlConnection could not be initialized (ResponseError: unconfigured table schema_keyspaces) +1ms
cassandra-store Database not available: unconfigured table schema_keyspaces +1ms