### PR TITLE
Updated express session due to security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "dependencies": {
         "cassandra-driver": "3.0.2",
-        "express-session": "1.13.0"
+        "express-session": "^1.15.6"
     },
     "devDependencies": {
         "mocha": "*"


### PR DESCRIPTION
Due to a security vulnerability in a  dependency in express session 1.13, we should upgrade express-session to 1.15 which updated the debug package to 2.6.9 which does not have the ddos regex security problem

https://snyk.io/vuln/npm:debug